### PR TITLE
Reproduce paper convergence

### DIFF
--- a/Examples/GradDotProd_LM/config_file.py
+++ b/Examples/GradDotProd_LM/config_file.py
@@ -4,77 +4,109 @@ import argparse
 import os
 import sys
 
+import torch
+
 # Add parent directories to path for imports
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from shared.utils import build_result_dir
 
-
 # Directory configurations
-RESULTS_DIR = '/scratch/gpfs/tw8948/GhostPub/GhostSuite/Results'
+RESULTS_DIR = "/scratch/gpfs/tw8948/GhostPub/GhostSuite/Results"
 
 # Dataset directories
-PILE_DATA_DIR = '/scratch/gpfs/tw8948/pile_tokenized'
-LLAVA_DATASET_DIR = '/scratch/gpfs/tw8948/llava_dataset'
+PILE_DATA_DIR = "/scratch/gpfs/tw8948/pile_tokenized"
+LLAVA_DATASET_DIR = "/scratch/gpfs/tw8948/llava_dataset"
 
 
 def parse_arguments():
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description='In-Run Data Shapley score computation.')
-    
+    parser = argparse.ArgumentParser(
+        description="In-Run Data Shapley score computation."
+    )
+
     # Method parameters
-    parser.add_argument('--method', type=str, default='Regular',
-                        choices=['Regular', 'GradDotProd'])
-    
+    parser.add_argument(
+        "--method", type=str, default="Regular", choices=["Regular", "GradDotProd"]
+    )
+
     # Architecture parameters
-    parser.add_argument('--architecture', type=str, default='GPT2-Small',
-                       choices=['GPT2-Small', 'GPT2-Medium', 'GPT2-Large', 'LLaVA-7B', 'LLaVA-13B'])
-    
+    parser.add_argument(
+        "--architecture",
+        type=str,
+        default="GPT2-Small",
+        choices=["GPT2-Small", "GPT2-Medium", "GPT2-Large", "LLaVA-7B", "LLaVA-13B"],
+    )
+
     # Training parameters
-    parser.add_argument('--batch_size', type=int, default=16, help='Training batch size')
-    parser.add_argument('--val_batch_size', type=int, default=1)
-    parser.add_argument('--warmup_step', type=int, default=2000)
-    parser.add_argument('--learning_rate', type=float, default=3e-4)
-    parser.add_argument('--optimizer', type=str, default='adamw')
-    parser.add_argument('--max_steps', type=int, default=50000)
-    parser.add_argument('--seed', type=int, default=42)
-    
+    parser.add_argument(
+        "--batch_size", type=int, default=16, help="Training batch size"
+    )
+    parser.add_argument("--val_batch_size", type=int, default=1)
+    parser.add_argument(
+        "--gradient_accumulation_steps",
+        type=int,
+        default=1,
+        help="Number of steps to accumulate gradients",
+    )
+    parser.add_argument(
+        "--grad_clip",
+        type=float,
+        default=1.0,
+        help="Gradient clipping value (0.0 to disable)",
+    )
+    parser.add_argument("--warmup_step", type=int, default=2000)
+    parser.add_argument("--learning_rate", type=float, default=3e-4)
+    parser.add_argument("--optimizer", type=str, default="adamw")
+    parser.add_argument("--max_steps", type=int, default=50000)
+    parser.add_argument("--seed", type=int, default=42)
+
     # Dataset parameters
-    parser.add_argument('--train_set', type=str, default='pile')
-    parser.add_argument('--val_set', type=str, default='pile', help='Validation dataset name; currently not used')
-    
+    parser.add_argument("--train_set", type=str, default="pile")
+    parser.add_argument(
+        "--val_set",
+        type=str,
+        default="pile",
+        help="Validation dataset name; currently not used",
+    )
+
     # Evaluation parameters
-    parser.add_argument('--eval_only', action='store_true')
-    parser.add_argument('--eval_interval', type=int, default=10)
-    parser.add_argument('--eval_iter', type=int, default=20)
-    parser.add_argument('--eval_bs', type=int, default=16)
+    parser.add_argument("--eval_only", action="store_true")
+    parser.add_argument("--eval_interval", type=int, default=10)
+    parser.add_argument("--eval_iter", type=int, default=20)
+    parser.add_argument("--eval_bs", type=int, default=16)
 
     # In-Run Shapley parameters
-    parser.add_argument('--dot_prod_save_interval', type=int, default=10)
-    
+    parser.add_argument("--dot_prod_save_interval", type=int, default=10)
+
     # Precision parameters
-    parser.add_argument('--model_dtype', type=str, default='bfloat16',
-                       choices=['float32', 'float16', 'bfloat16'], 
-                       help='Model data type')
-    parser.add_argument('--train_dtype', type=str, default='bfloat16',
-                       choices=['float32', 'float16', 'bfloat16'], 
-                       help='Training data type')
+    parser.add_argument(
+        "--model_dtype",
+        type=str,
+        default="bfloat16",
+        choices=["float32", "float16", "bfloat16"],
+        help="Model data type",
+    )
+    parser.add_argument(
+        "--train_dtype",
+        type=str,
+        default="bfloat16",
+        choices=["float32", "float16", "bfloat16"],
+        help="Training data type",
+    )
 
     return parser.parse_args()
 
 
-
-
 class TrainingConfig:
     """Training configuration class."""
-    
-    def __init__(self, args):
 
+    def __init__(self, args):
         self.args = args
 
         # Defer the model config to a separate function
         self.architecture = args.architecture
-        
+
         # Training hyperparameters
         self.batch_size = args.batch_size
         self.val_batch_size = args.val_batch_size
@@ -82,21 +114,21 @@ class TrainingConfig:
         self.min_lr = self.learning_rate * 0.1
         self.max_steps = args.max_steps
         self.seed = args.seed
-        
+
         # Optimizer settings (currently just assume using AdamW)
         self.optimizer = args.optimizer
         self.weight_decay = 1e-1
         self.beta1 = 0.9
         self.beta2 = 0.95
-        self.grad_clip = 1.0
+        self.grad_clip = args.grad_clip
         self.warmup_iters = args.warmup_step
         self.lr_decay_iters = 10000
         self.decay_lr = True
-        
+
         # System settings
-        self.device = 'cuda'
+        self.device = "cuda"
         self.compile = False
-        self.backend = 'nccl'
+        self.backend = "nccl"
 
         # Precision settings
         # Note: we never use float16 for stability
@@ -106,8 +138,12 @@ class TrainingConfig:
 
         # Gradient accumulation
         self.full_batch_size = args.batch_size
-        self.gradient_accumulation_steps = 1
-        
+        self.gradient_accumulation_steps = (
+            args.gradient_accumulation_steps
+            if hasattr(args, "gradient_accumulation_steps")
+            else 1
+        )
+
         # Evaluation settings
         self.eval_iters = args.eval_iter
         self.eval_interval = args.eval_interval
@@ -116,21 +152,19 @@ class TrainingConfig:
 
         if self.dot_prod_save_interval is None:
             self.dot_prod_save_interval = self.eval_interval
-        
+
         # Method-specific settings
         self.method = args.method
-        
+
         # Result directory setup (larger folder)
         self.result_folder = RESULTS_DIR
         self.setup_result_directories()
-    
+
     def _is_bf16_supported(self):
         """Check if bfloat16 is supported."""
-        import torch
         return torch.cuda.is_available() and torch.cuda.is_bf16_supported()
-    
-    def setup_result_directories(self):
 
+    def setup_result_directories(self):
         # Create result folder if it doesn't exist
         if not os.path.exists(self.result_folder):
             os.makedirs(self.result_folder)
@@ -138,14 +172,14 @@ class TrainingConfig:
 
         # Create specific result directory for this run
         self.result_dir = build_result_dir(self.result_folder, self.method, self.args)
-        
+
         if not os.path.exists(self.result_dir):
             os.makedirs(self.result_dir)
-            print(f"Results directory for this specific run '{self.result_dir}' was created.")
-    
+            print(
+                f"Results directory for this specific run '{self.result_dir}' was created."
+            )
+
     def get_result_file_path(self):
         """Get the result file path for storing training statistics."""
         result_dir = self.result_dir
-        return os.path.join(result_dir + '_results.json')
-
-
+        return os.path.join(result_dir + "_results.json")

--- a/Examples/GradDotProd_LM/training_loop.py
+++ b/Examples/GradDotProd_LM/training_loop.py
@@ -3,6 +3,8 @@
 import os
 import sys
 
+import torch
+
 # Add parent directories to path for imports
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(
@@ -102,14 +104,6 @@ class Trainer:
     def _training_step(self, iter_num):
         """Perform one complete training step including data loading, LR update, and ghost engine operations."""
 
-        # Get training batch
-        X, Y, batch_idx = self.get_batch(
-            "train", batch_size=self.config.batch_size, return_idx=True
-        )
-
-        # Store batch info for ghost engine
-        self.ghost_engine.attach_train_batch(X, Y, iter_num, batch_idx)
-
         # Update learning rate
         lr = (
             get_learning_rate(iter_num, self.config)
@@ -123,10 +117,18 @@ class Trainer:
             if self.ghost_engine.should_save_metrics(iter_num):
                 self.ghost_engine.save_metrics(iter_num)
 
-        loss = None
+        step_loss = 0.0
 
         # Forward and backward pass with gradient accumulation
         for micro_step in range(self.config.gradient_accumulation_steps):
+            #  Get training batch
+            X, Y, batch_idx = self.get_batch(
+                "train", batch_size=self.config.batch_size, return_idx=True
+            )
+
+            # Store batch info for ghost engine
+            self.ghost_engine.attach_train_batch(X, Y, iter_num, batch_idx)
+
             if self.ddp_info["ddp"]:
                 self.model.require_backward_grad_sync = (
                     micro_step == self.config.gradient_accumulation_steps - 1
@@ -137,39 +139,39 @@ class Trainer:
                 X_forward, _ = self.ghost_engine.prepare_forward_input(X, Y)
 
                 # Forward pass with method-appropriate input
-                # FIX: Pass X_forward as labels. The GPT2LMHeadModel shifts labels internally.
-                # If we pass Y (already shifted), it gets shifted twice, causing a mismatch.
                 outputs = self.model(input_ids=X_forward, labels=X_forward)
                 logits, loss = outputs.logits, outputs.loss
 
                 # Scale loss for gradient accumulation
                 if loss is not None:
                     loss = loss / self.config.gradient_accumulation_steps
+                    step_loss += loss.item()
 
             # Backward pass
             if loss is not None:
                 self.scaler.scale(loss).backward()
 
+            # Aggregate metrics
+            self.ghost_engine.aggregate_and_log()
+
         # Prepare gradients using ghost engine
         self.ghost_engine.prepare_gradients()
 
-        print(
-            f"Step {iter_num}, Loss: {loss.item() if loss is not None else 'N/A'}, LR: {lr:.6f}"
-        )
+        print(f"Step {iter_num}, Loss: {step_loss:.4f}, LR: {lr:.7f}")
 
         # Gradient clipping and optimization step
         self.scaler.unscale_(self.optimizer)
-
-        # if self.config.grad_clip != 0.0:
-        #     torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.config.grad_clip)
+        if self.config.grad_clip != 0.0:
+            torch.nn.utils.clip_grad_norm_(
+                self.model.parameters(), self.config.grad_clip
+            )
 
         # This will call the custom engine's step() if it's enabled, which computes values
         # before calling the original optimizer step.
         self.scaler.step(self.optimizer)
         self.scaler.update()
 
-        # Aggregate metrics and clear gradients using ghost engine
-        self.ghost_engine.aggregate_and_log()
+        # clear gradients using ghost engine
         self.ghost_engine.clear_gradients()
 
         self.optimizer.zero_grad(set_to_none=True)

--- a/Examples/GradDotProd_LM/training_loop.py
+++ b/Examples/GradDotProd_LM/training_loop.py
@@ -1,34 +1,41 @@
 """Main training loop implementation."""
 
-import time
-import numpy as np
-import torch
 import os
 import sys
 
 # Add parent directories to path for imports
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.append(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 
 # Local imports
 from shared.training_utils import (
-    get_learning_rate,
-    update_learning_rate,
     estimate_loss,
-    save_training_results, 
-    to_device
+    get_learning_rate,
+    save_training_results,
+    to_device,
+    update_learning_rate,
 )
 
 # Ghost Engines
 from ghostEngines import GhostEngineManager
 
 
-class Trainer: 
+class Trainer:
     """Main trainer class that orchestrates the training process."""
-    
-    def __init__(self, model, optimizer, scaler, config, ddp_info, 
-                 get_batch_fn, get_val_batch_fn, ctx):
-        
+
+    def __init__(
+        self,
+        model,
+        optimizer,
+        scaler,
+        config,
+        ddp_info,
+        get_batch_fn,
+        get_val_batch_fn,
+        ctx,
+    ):
         print("[INFO] Initializing Trainer ...")
 
         self.model = model
@@ -39,121 +46,123 @@ class Trainer:
         self.get_batch = get_batch_fn
         self.get_val_batch = get_val_batch_fn
         self.ctx = ctx
-        
+
         # Training state
         self.iter_num = 0
         self.best_val_loss = 1e9
 
         # Prepare validation data for ghost engines (if needed)
         val_data = None
-        if self.config.method == 'GradDotProd':
+        if self.config.method == "GradDotProd":
             X_val, Y_val = self.get_val_batch(
                 self.config.val_batch_size, return_idx=False
             )
-            X_val = to_device(X_val, self.ddp_info['device'])
-            Y_val = to_device(Y_val, self.ddp_info['device'])
+            X_val = to_device(X_val, self.ddp_info["device"])
+            Y_val = to_device(Y_val, self.ddp_info["device"])
             val_data = (X_val, Y_val)
 
         # Initialize ghost engine manager
         self.ghost_engine = GhostEngineManager(
             config=self.config,
-            model=self.model, 
+            model=self.model,
             optimizer=self.optimizer,
             ddp_info=self.ddp_info,
-            val_data=val_data
+            val_data=val_data,
         )
 
-
     def run_training(self):
-
         print("[INFO] Starting training...")
-        
-        result_file = self.config.get_result_file_path()
-        
-        try:
-            
-            while self.iter_num < self.config.max_steps:
 
+        result_file = self.config.get_result_file_path()
+
+        try:
+            while self.iter_num < self.config.max_steps:
                 # Evaluation every eval_interval steps
                 if self.iter_num % self.config.eval_interval == 0:
                     self._run_evaluation(result_file)
 
                 if self.config.args.eval_only:
-                    print('Eval only mode, exiting now')
+                    print("Eval only mode, exiting now")
                     break
-                
+
                 # Perform complete training step
                 self._training_step(self.iter_num)
-                                
+
                 self.iter_num += 1
-            
+
         except Exception as e:
             print(f"Error during training: {e}")
             import traceback
+
             traceback.print_exc()
-        
+
         finally:
             self._cleanup(result_file)
-    
 
     def _training_step(self, iter_num):
         """Perform one complete training step including data loading, LR update, and ghost engine operations."""
-        
+
         # Get training batch
         X, Y, batch_idx = self.get_batch(
-            'train', 
-            batch_size=self.config.batch_size, 
-            return_idx=True
+            "train", batch_size=self.config.batch_size, return_idx=True
         )
 
         # Store batch info for ghost engine
         self.ghost_engine.attach_train_batch(X, Y, iter_num, batch_idx)
-        
+
         # Update learning rate
-        lr = get_learning_rate(iter_num, self.config) if self.config.decay_lr else self.config.learning_rate
+        lr = (
+            get_learning_rate(iter_num, self.config)
+            if self.config.decay_lr
+            else self.config.learning_rate
+        )
         update_learning_rate(self.optimizer, lr)
-        
+
         # Save ghost engine metrics at their own interval (before training step)
-        if iter_num > 0 and self.ddp_info['master_process']:
+        if iter_num > 0 and self.ddp_info["master_process"]:
             if self.ghost_engine.should_save_metrics(iter_num):
                 self.ghost_engine.save_metrics(iter_num)
-        
+
         loss = None
 
         # Forward and backward pass with gradient accumulation
         for micro_step in range(self.config.gradient_accumulation_steps):
-            if self.ddp_info['ddp']:
+            if self.ddp_info["ddp"]:
                 self.model.require_backward_grad_sync = (
                     micro_step == self.config.gradient_accumulation_steps - 1
                 )
-            
+
             with self.ctx:
                 # Prepare input based on the ghost engine method
-                X_forward, Y_forward = self.ghost_engine.prepare_forward_input(X, Y)
-                
+                X_forward, _ = self.ghost_engine.prepare_forward_input(X, Y)
+
                 # Forward pass with method-appropriate input
-                outputs = self.model(input_ids=X_forward, labels=Y_forward)
+                # FIX: Pass X_forward as labels. The GPT2LMHeadModel shifts labels internally.
+                # If we pass Y (already shifted), it gets shifted twice, causing a mismatch.
+                outputs = self.model(input_ids=X_forward, labels=X_forward)
                 logits, loss = outputs.logits, outputs.loss
-                
+
                 # Scale loss for gradient accumulation
                 if loss is not None:
                     loss = loss / self.config.gradient_accumulation_steps
-            
+
             # Backward pass
             if loss is not None:
                 self.scaler.scale(loss).backward()
-        
+
         # Prepare gradients using ghost engine
         self.ghost_engine.prepare_gradients()
 
-        print(f"Step {iter_num}, Loss: {loss.item() if loss is not None else 'N/A'}, LR: {lr:.6f}")
+        print(
+            f"Step {iter_num}, Loss: {loss.item() if loss is not None else 'N/A'}, LR: {lr:.6f}"
+        )
 
         # Gradient clipping and optimization step
         self.scaler.unscale_(self.optimizer)
-        
+
         # if self.config.grad_clip != 0.0:
         #     torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.config.grad_clip)
-        
+
         # This will call the custom engine's step() if it's enabled, which computes values
         # before calling the original optimizer step.
         self.scaler.step(self.optimizer)
@@ -164,10 +173,8 @@ class Trainer:
         self.ghost_engine.clear_gradients()
 
         self.optimizer.zero_grad(set_to_none=True)
-    
 
     def _run_evaluation(self, result_file):
-
         # Detach ghost engines during evaluation
         self.ghost_engine.detach_for_evaluation()
 
@@ -176,13 +183,16 @@ class Trainer:
         # Reattach ghost engines after evaluation
         self.ghost_engine.reattach_after_evaluation()
 
-        train_loss, val_loss, test_loss = losses['train'], losses['val'], losses['test']
-        
-        print(f"step {self.iter_num}: train loss {train_loss:.4f}, "
-              f"val loss {val_loss:.4f}, test loss {test_loss:.4f}")
-        
-        save_training_results(result_file, train_loss, val_loss, test_loss, self.iter_num)
+        train_loss, val_loss, test_loss = losses["train"], losses["val"], losses["test"]
 
+        print(
+            f"step {self.iter_num}: train loss {train_loss:.4f}, "
+            f"val loss {val_loss:.4f}, test loss {test_loss:.4f}"
+        )
+
+        save_training_results(
+            result_file, train_loss, val_loss, test_loss, self.iter_num
+        )
 
     def _cleanup(self, result_file):
         """Cleanup training resources and run a final evaluation."""

--- a/Examples/shared/model_setup.py
+++ b/Examples/shared/model_setup.py
@@ -1,9 +1,12 @@
 """Model setup and initialization utilities."""
 
+import math
+
 import torch
+from torch import nn
 from torch.nn.parallel import DistributedDataParallel as DDP
-from transformers import GPT2Config, GPT2LMHeadModel as GPT 
-from transformers import LlavaForConditionalGeneration
+from transformers import GPT2Config, LlavaForConditionalGeneration
+from transformers import GPT2LMHeadModel as GPT
 
 
 def setup_model_and_optimizer(config, device, ddp_info):
@@ -15,22 +18,22 @@ def setup_model_and_optimizer(config, device, ddp_info):
     model = create_model(config)
     model.to(device)
     print(f"[INFO] Model created and moved to {device}.")
-    
+
     # Setup optimizer and scaler
     print("[INFO] Setting up optimizer and scaler...")
-    optimizer, scaler = setup_adamw_optimizer_and_scaler(model, config)
+    optimizer, scaler = setup_adamw_optimizer_and_scaler(model, config, device)
     print("[INFO] Optimizer and scaler set up.")
-    
+
     # Compile model if requested
     if config.compile:
         print("Compiling the model ...")
         model = torch.compile(model)
         print("Model compiled successfully.")
-    
+
     # Wrap in DDP if distributed
-    if ddp_info['ddp']:
-        model = DDP(model, device_ids=[ddp_info['ddp_local_rank']])
-    
+    if ddp_info["ddp"]:
+        model = DDP(model, device_ids=[ddp_info["ddp_local_rank"]])
+
     return model, optimizer, scaler
 
 
@@ -39,53 +42,53 @@ def get_raw_model(model, ddp):
     return model.module if ddp else model
 
 
-
-def setup_adamw_optimizer_and_scaler(model, config):
+def setup_adamw_optimizer_and_scaler(model, config, device):
     """Setup AdamW optimizer and gradient scaler"""
 
     weight_decay = config.weight_decay
     learning_rate = config.learning_rate
     beta1 = config.beta1
     beta2 = config.beta2
-    
+
     # Separate parameters that should and shouldn't have weight decay
     decay_params = []
     no_decay_params = []
-    
+
     for name, param in model.named_parameters():
         if param.requires_grad:
             # Don't apply weight decay to bias terms and layer norm parameters
-            if any(nd in name for nd in ['bias', 'norm', 'ln']):
+            if any(nd in name for nd in ["bias", "norm", "ln"]):
                 no_decay_params.append(param)
             else:
                 decay_params.append(param)
-    
+
     # Create parameter groups
     param_groups = [
-        {'params': decay_params, 'weight_decay': weight_decay},
-        {'params': no_decay_params, 'weight_decay': 0.0}
+        {"params": decay_params, "weight_decay": weight_decay},
+        {"params": no_decay_params, "weight_decay": 0.0},
     ]
-    
+
     # Create optimizer
+    fused_available = "fused" in torch.optim.AdamW.__init__.__code__.co_varnames
+    use_fused = fused_available and "cuda" in str(device)
+    print(f"[INFO] Using FusedAdamW: {use_fused}")
+
     optimizer = torch.optim.AdamW(
-        param_groups,
-        lr=learning_rate,
-        betas=(beta1, beta2),
-        eps=1e-8
+        param_groups, lr=learning_rate, betas=(beta1, beta2), eps=1e-8, fused=use_fused
     )
-    
+
     # Create gradient scaler for mixed precision training with fp16
-    enable_grad_scaler = (config.train_dtype == 'float16' and next(model.parameters()).dtype == torch.float32)
-    scaler = torch.amp.GradScaler('cuda', enabled=enable_grad_scaler)
+    enable_grad_scaler = (
+        config.train_dtype == "float16"
+        and next(model.parameters()).dtype == torch.float32
+    )
+    scaler = torch.amp.GradScaler("cuda", enabled=enable_grad_scaler)
 
-    print(f"[INFO] Model parameters will be in {next(model.parameters()).dtype} precision.")
-    
+    print(
+        f"[INFO] Model parameters will be in {next(model.parameters()).dtype} precision."
+    )
+
     return optimizer, scaler
-
-
-
-
-
 
 
 def create_model(config):
@@ -97,7 +100,7 @@ def create_model(config):
         model = create_GPT_model(config)
     else:
         raise ValueError(f"Unknown architecture: {config.architecture}")
-    
+
     return model
 
 
@@ -105,27 +108,27 @@ def create_GPT_model(config):
     """Create and initialize the GPT model."""
 
     config_GPT = {
-        'GPT2-Small': {
-            'n_layer': 12,
-            'n_head': 12,
-            'n_embd': 768,
-            'block_size': 1024,
-            'vocab_size': 50304,
+        "GPT2-Small": {
+            "n_layer": 12,
+            "n_head": 12,
+            "n_embd": 768,
+            "block_size": 1024,
+            "vocab_size": 50304,
         },
-        'GPT2-Medium': {
-            'n_layer': 24,
-            'n_head': 12,
-            'n_embd': 1024,
-            'block_size': 1024,
-            'vocab_size': 50304,
+        "GPT2-Medium": {
+            "n_layer": 24,
+            "n_head": 12,
+            "n_embd": 1024,
+            "block_size": 1024,
+            "vocab_size": 50304,
         },
-        'GPT2-Large': {
-            'n_layer': 36,
-            'n_head': 20,
-            'n_embd': 1280,
-            'block_size': 1024,
-            'vocab_size': 50304,
-        }
+        "GPT2-Large": {
+            "n_layer": 36,
+            "n_head": 20,
+            "n_embd": 1280,
+            "block_size": 1024,
+            "vocab_size": 50304,
+        },
     }
 
     if config.architecture not in config_GPT:
@@ -134,23 +137,32 @@ def create_GPT_model(config):
     model_config = config_GPT[config.architecture]
 
     model_args = dict(
-        n_layer=model_config['n_layer'],
-        n_head=model_config['n_head'],
-        n_embd=model_config['n_embd'],
-        n_positions=model_config['block_size'],
-        bos_token_id=model_config['vocab_size'],
-        eos_token_id=model_config['vocab_size'],
-        vocab_size=model_config['vocab_size'],
+        n_layer=model_config["n_layer"],
+        n_head=model_config["n_head"],
+        n_embd=model_config["n_embd"],
+        n_positions=model_config["block_size"],
+        bos_token_id=model_config["vocab_size"],
+        eos_token_id=model_config["vocab_size"],
+        vocab_size=model_config["vocab_size"],
         resid_pdrop=0,
         embd_pdrop=0,
         attn_pdrop=0,
         summary_first_dropout=0,
         use_cache=False,
+        attn_implementation="sdpa",
     )
-    
+
     gptconf = GPT2Config(**model_args)
     model = GPT(gptconf)
-    
+
+    print(
+        f"[INFO] Re-initializing residual projections with 1/sqrt(2 * {model_config['n_layer']})..."
+    )
+    for name, p in model.named_parameters():
+        if name.endswith("c_proj.weight"):
+            scale = 0.02 / math.sqrt(2 * model_config["n_layer"])
+            torch.nn.init.normal_(p, mean=0.0, std=scale)
+
     return model
 
 
@@ -176,19 +188,20 @@ def create_llava_model(config):
 
     # Freeze the vision tower parameters
     for p in model.base_model.model.vision_tower.parameters():
-        p.requires_grad = False        # CLIP ViT is frozen
+        p.requires_grad = False  # CLIP ViT is frozen
 
-    print(f"[INFO] LLaVA model {config.args.architecture} created with vision tower frozen.")
+    print(
+        f"[INFO] LLaVA model {config.args.architecture} created with vision tower frozen."
+    )
 
     return model
 
 
-from torch import nn
 class LLaVAModelWrapper(nn.Module):
     def __init__(self, base_model):
         super().__init__()
         self.base_model = base_model
-    
+
     def forward(self, input_ids, labels=None, **kwargs):
         # If input_ids is a dict, unpack it
         if isinstance(input_ids, dict):
@@ -196,11 +209,9 @@ class LLaVAModelWrapper(nn.Module):
         else:
             # Regular model call for non-LLaVA models
             return self.base_model(input_ids=input_ids, labels=labels, **kwargs)
-    
+
     def __getattr__(self, name):
         # Delegate all other attributes to the base model
-        if name == 'base_model':
+        if name == "base_model":
             return super().__getattr__(name)
         return getattr(self.base_model, name)
-
-

--- a/Examples/shared/training_utils.py
+++ b/Examples/shared/training_utils.py
@@ -1,23 +1,20 @@
 """Training utilities and helper functions."""
 
-import os
-import time
-import math
 import json
+import math
+import os
 import pickle
-import threading
 import queue
-import numpy as np
-
-import torch
-from torch.distributed import init_process_group, destroy_process_group
+import threading
 from contextlib import nullcontext
 
+import torch
+from torch.distributed import destroy_process_group, init_process_group
 
 # Data loaders for language datasets
 from .dataloader import (
-    load_all_data,
     get_batch_from_dataset,
+    load_all_data,
 )
 
 # Note: llava_dataloader would need to be moved to shared/ or handled separately
@@ -28,7 +25,13 @@ from .dataloader import (
 # )
 
 
-LLAVA_LIST = ["conversation_58k", "complex_reasoning_77k", "detail_23k", "llava_instruct_80k", "llava_instruct_150k"]
+LLAVA_LIST = [
+    "conversation_58k",
+    "complex_reasoning_77k",
+    "detail_23k",
+    "llava_instruct_80k",
+    "llava_instruct_150k",
+]
 
 
 def load_dataset_main(train_set, val_set):
@@ -38,25 +41,31 @@ def load_dataset_main(train_set, val_set):
     print(f"[INFO] Loading {train_set} dataset ...")
 
     if train_set in LLAVA_LIST:
-        # Dynamically import llava_dataloader only when needed
-        import sys
+        # ... (keep existing LLAVA code) ...
         import os
-        sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+        import sys
+
+        sys.path.append(
+            os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        )
         from llava_dataloader import load_llava_dataset
-        
+
         dataset = load_llava_dataset(
             dataset_name=train_set,
-            tokenizer_name="llava-hf/llava-1.5-7b-hf", 
+            tokenizer_name="llava-hf/llava-1.5-7b-hf",
             max_length=1024,
         )
-    elif train_set == 'pile':
-        dataset = load_all_data()
+    elif train_set == "pile":
+        # --- FIX START ---
+        # Load all 16 domains to match the paper's distribution
+        # Default was num_domains=1 (Pile-CC only), which caused poor convergence
+        dataset = load_all_data(num_domains=16)
+        # --- FIX END ---
     else:
         raise ValueError(f"Unsupported training set: {train_set}")
-    
+
     print(f"[INFO] Dataset '{train_set}' loaded successfully.")
     return dataset
-
 
 
 # TODO: Clean up this data loader function further; currently a bit messy due to different dataset handling
@@ -72,91 +81,100 @@ def setup_data_functions(dataset, config, device):
     test_gen = torch.Generator()
     test_gen.manual_seed(config.seed + 2)
 
-    generators = {'train': train_gen, 'val': val_gen, 'test': test_gen}
+    generators = {"train": train_gen, "val": val_gen, "test": test_gen}
 
-    if config.args.train_set == 'pile':
+    if config.args.train_set == "pile":
+
         def get_batch(split, batch_size, return_idx=False):
             gen = generators.get(split, train_gen)
             return get_batch_from_dataset(
                 split, batch_size, dataset, return_idx=return_idx, generator=gen
             )
+
         def get_val_batch(batch_size, return_idx=False):
-            return get_batch('val', batch_size, return_idx=return_idx)
-        
+            return get_batch("val", batch_size, return_idx=return_idx)
+
     elif config.args.train_set in LLAVA_LIST:
         # Dynamically import llava_dataloader only when needed
-        import sys
         import os
-        sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+        import sys
+
+        sys.path.append(
+            os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        )
         from llava_dataloader import get_llava_batch
 
         def get_batch(split, batch_size, return_idx=False):
-
             gen = generators.get(split, train_gen)
-            
+
             # Get the batch from llava dataloader
             batch_data = get_llava_batch(
                 split, batch_size, dataset, device=device, generator=gen
             )
-            
+
             # Unpack based on what was returned (3 or 4 items)
             if len(batch_data) == 3:
                 input_ids, pixel_values, labels = batch_data
                 attention_mask = None
             else:
                 input_ids, pixel_values, labels, attention_mask = batch_data
-            
+
             # Create a dict for X that contains all inputs needed by the model
             X = {
-                'input_ids': input_ids,
-                'pixel_values': pixel_values,
+                "input_ids": input_ids,
+                "pixel_values": pixel_values,
             }
-            
+
             # Add attention_mask if it exists
             if attention_mask is not None:
-                X['attention_mask'] = attention_mask
-            
+                X["attention_mask"] = attention_mask
+
             # For return_idx, we need to track which indices were sampled
             if return_idx:
                 # Generate the same indices that were used in get_llava_batch
                 if gen is None:
-                    raise ValueError("Generator must be provided for return_idx functionality.")
+                    raise ValueError(
+                        "Generator must be provided for return_idx functionality."
+                    )
                 else:
-                    idx = torch.randint(len(dataset[split]), (batch_size,), generator=gen)
+                    idx = torch.randint(
+                        len(dataset[split]), (batch_size,), generator=gen
+                    )
                 return X, labels, idx
             else:
                 return X, labels
-        
+
         def get_val_batch(batch_size, return_idx=False):
-            return get_batch('val', batch_size, return_idx=return_idx)
-        
+            return get_batch("val", batch_size, return_idx=return_idx)
+
     else:
         raise ValueError(f"Unsupported training set: {config.args.train_set}")
-    
-    return get_batch, get_val_batch
 
+    return get_batch, get_val_batch
 
 
 def to_device(data, device):
     """Move data to device, handling both tensors and dicts of tensors."""
     if isinstance(data, dict):
-        return {k: v.to(device) if hasattr(v, 'to') else v for k, v in data.items()}
-    elif hasattr(data, 'to'):
+        return {k: v.to(device) if hasattr(v, "to") else v for k, v in data.items()}
+    elif hasattr(data, "to"):
         return data.to(device)
     else:
-        raise TypeError(f"Unsupported data type for moving to GPU: {type(data)}. Expected tensor or dict of tensors.")
+        raise TypeError(
+            f"Unsupported data type for moving to GPU: {type(data)}. Expected tensor or dict of tensors."
+        )
 
 
 def setup_distributed():
     """Setup distributed training if available."""
-    ddp = int(os.environ.get('RANK', -1)) != -1
-    
+    ddp = int(os.environ.get("RANK", -1)) != -1
+
     if ddp:
-        init_process_group(backend='nccl')
-        ddp_rank = int(os.environ['RANK'])
-        ddp_local_rank = int(os.environ['LOCAL_RANK'])
-        ddp_world_size = int(os.environ['WORLD_SIZE'])
-        device = f'cuda:{ddp_local_rank}'
+        init_process_group(backend="nccl")
+        ddp_rank = int(os.environ["RANK"])
+        ddp_local_rank = int(os.environ["LOCAL_RANK"])
+        ddp_world_size = int(os.environ["WORLD_SIZE"])
+        device = f"cuda:{ddp_local_rank}"
         torch.cuda.set_device(device)
         master_process = ddp_rank == 0
         seed_offset = ddp_rank
@@ -166,26 +184,25 @@ def setup_distributed():
         ddp_world_size = 1
         ddp_rank = 0
         ddp_local_rank = 0
-        device = 'cuda'
-    
+        device = "cuda"
+
     return {
-        'ddp': ddp,
-        'ddp_rank': ddp_rank,
-        'ddp_local_rank': ddp_local_rank,
-        'ddp_world_size': ddp_world_size,
-        'device': device,
-        'master_process': master_process,
-        'seed_offset': seed_offset
+        "ddp": ddp,
+        "ddp_rank": ddp_rank,
+        "ddp_local_rank": ddp_local_rank,
+        "ddp_world_size": ddp_world_size,
+        "device": device,
+        "master_process": master_process,
+        "seed_offset": seed_offset,
     }
 
 
 def setup_torch_backend(config):
-
     torch.backends.cuda.matmul.allow_tf32 = True
     torch.backends.cudnn.allow_tf32 = True
 
-    if 'cuda' in config.device:
-        device_type = 'cuda'
+    if "cuda" in config.device:
+        device_type = "cuda"
     else:
         raise ValueError(f"Unsupported device type: {config.device}. Expected 'cuda'")
 
@@ -194,12 +211,12 @@ def setup_torch_backend(config):
     else:
         # TODO: Better handle dtype conversion
         ptdtype = {
-            'float32': torch.float32,
-            'bfloat16': torch.bfloat16,
-            'float16': torch.float16
+            "float32": torch.float32,
+            "bfloat16": torch.bfloat16,
+            "float16": torch.float16,
         }[config.train_dtype]
         ctx = torch.amp.autocast(device_type=device_type, dtype=ptdtype)
-    
+
     return ctx
 
 
@@ -207,12 +224,14 @@ def get_learning_rate(iteration, config):
     """Get learning rate for current iteration using cosine schedule with warmup."""
     if iteration < config.warmup_iters:
         return config.learning_rate * iteration / config.warmup_iters
-    
+
     if iteration > config.lr_decay_iters:
         return config.min_lr
-    
+
     # Cosine decay
-    decay_ratio = (iteration - config.warmup_iters) / (config.lr_decay_iters - config.warmup_iters)
+    decay_ratio = (iteration - config.warmup_iters) / (
+        config.lr_decay_iters - config.warmup_iters
+    )
     assert 0 <= decay_ratio <= 1
     coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))
     return config.min_lr + coeff * (config.learning_rate - config.min_lr)
@@ -221,20 +240,20 @@ def get_learning_rate(iteration, config):
 def update_learning_rate(optimizer, lr):
     """Update learning rate for all parameter groups."""
     for param_group in optimizer.param_groups:
-        param_group['lr'] = lr
+        param_group["lr"] = lr
 
 
 @torch.no_grad()
 def estimate_loss(model, get_batch_fn, config, ctx):
     """Estimate loss on train/val/test splits."""
     model.eval()
-    
+
     out = {}
-    for split in ['train', 'val', 'test']:
+    for split in ["train", "val", "test"]:
         losses = torch.zeros(config.eval_iters)
         for k in range(config.eval_iters):
             X, Y = get_batch_fn(split, batch_size=config.eval_bs)
-            
+
             # with ctx:
             #     outputs = model(input_ids=X, labels=Y)
 
@@ -246,12 +265,12 @@ def estimate_loss(model, get_batch_fn, config, ctx):
                 if pixel_values is not None:
                     outputs = model(input_ids=X, pixel_values=pixel_values, labels=Y)
                 else:
-                    outputs = model(input_ids=X, labels=Y)
+                    outputs = model(input_ids=X, labels=X)
                 logits, loss = outputs.logits, outputs.loss
 
             losses[k] = loss.item()
         out[split] = losses.mean()
-    
+
     model.train()
     return out
 
@@ -264,17 +283,23 @@ def save_training_results(file_path, train_loss, val_loss, test_loss, step):
             record = json.load(file)
     else:
         record = []
-    
+
     # Add new entry
     new_entry = {
-        "train_loss": train_loss.item() if isinstance(train_loss, torch.Tensor) else train_loss,
-        "eval_loss": val_loss.item() if isinstance(val_loss, torch.Tensor) else val_loss,
-        "test_loss": test_loss.item() if isinstance(test_loss, torch.Tensor) else test_loss,
-        "step": step
+        "train_loss": train_loss.item()
+        if isinstance(train_loss, torch.Tensor)
+        else train_loss,
+        "eval_loss": val_loss.item()
+        if isinstance(val_loss, torch.Tensor)
+        else val_loss,
+        "test_loss": test_loss.item()
+        if isinstance(test_loss, torch.Tensor)
+        else test_loss,
+        "step": step,
     }
-    
+
     record.append(new_entry)
-    
+
     # Write back to file
     with open(file_path, "w") as file:
         json.dump(record, file, indent=4)
@@ -285,28 +310,30 @@ def shapley_value_processor(q, value_record, lock):
     while True:
         try:
             item = q.get(timeout=1.0)
-            
+
             if item is None:  # Sentinel value to stop
                 print("Shapley processor received shutdown signal")
                 q.task_done()
                 break
-            
+
             first_order_score_gpu, batch_idx, lr = item
-            
+
             try:
                 first_order_value = first_order_score_gpu.cpu().numpy()
             except Exception as e:
                 print(f"Error converting tensor to numpy: {e}")
                 q.task_done()
                 continue
-            
+
             # Store values with thread safety
             with lock:
-                value_record['index'].append(batch_idx)
-                value_record['First-order In-Run Data Shapley'].append(first_order_value)
-            
+                value_record["index"].append(batch_idx)
+                value_record["First-order In-Run Data Shapley"].append(
+                    first_order_value
+                )
+
             q.task_done()
-            
+
         except queue.Empty:
             continue
         except Exception as e:
@@ -319,57 +346,50 @@ def shapley_value_processor(q, value_record, lock):
 
 class ShapleyProcessor:
     """Handles asynchronous Shapley value processing."""
-    
+
     def __init__(self, queue_size=10):
-        self.value_record = {
-            'index': [],
-            'First-order In-Run Data Shapley': []
-        }
+        self.value_record = {"index": [], "First-order In-Run Data Shapley": []}
         self.data_queue = queue.Queue(maxsize=queue_size)
         self.lock = threading.Lock()
         self.thread = None
-    
+
     def start(self):
         """Start the processing thread."""
         self.thread = threading.Thread(
             target=shapley_value_processor,
-            args=(self.data_queue, self.value_record, self.lock)
+            args=(self.data_queue, self.value_record, self.lock),
         )
         self.thread.start()
-    
+
     def add_values(self, first_order_score, batch_idx, lr, timeout=5.0):
         """Add values to processing queue."""
-        data_to_queue = (
-            first_order_score.detach(),
-            batch_idx,
-            lr
-        )
+        data_to_queue = (first_order_score.detach(), batch_idx, lr)
         try:
             self.data_queue.put(data_to_queue, timeout=timeout)
         except queue.Full:
             print("Warning: Shapley processing queue is full, skipping this batch")
-    
+
     def shutdown(self, timeout=10.0):
         """Shutdown the processing thread."""
         print("Shutting down Shapley value processing...")
-        
+
         try:
             self.data_queue.put(None, timeout=2.0)
         except queue.Full:
             print("Warning: Could not send shutdown signal to queue")
-        
+
         if self.thread and self.thread.is_alive():
             self.thread.join(timeout=timeout)
             if self.thread.is_alive():
                 print("Warning: Worker thread did not shut down gracefully")
             else:
                 print("Shapley value processing finished.")
-    
+
     def save_values(self, file_path):
         """Save collected values to file."""
         try:
             with self.lock:
-                pickle.dump(self.value_record, open(file_path + '.value', 'wb'))
+                pickle.dump(self.value_record, open(file_path + ".value", "wb"))
                 print(f"Shapley values saved to {file_path}.value")
         except Exception as e:
             print(f"Error saving Shapley values: {e}")


### PR DESCRIPTION
Key Changes:
* Load all 16 Pile domains (instead of just Pile-CC)
* Fix "double-shifting" bug by passing `input_ids` as labels (since [`GPT2LMHeadModel` shifts internally](https://huggingface.co/docs/transformers/en/model_doc/gpt2#transformers.GPT2LMHeadModel.forward.labels)).
* Add scaled weight initialization for residual projections and enable SDPA
* Include gradient accumulation that was 1 by default
* Uncomment and apply gradient clipping

The training now converges as in the paper (test loss ~3.5 after 5k iterations).
<img width="572" height="441" alt="original" src="https://github.com/user-attachments/assets/e952ab03-869f-486d-96f8-73db9a900322" />

I achieved this plot with the following command:
```bash
python main.py \
    --method "Regular" \
    --architecture "GPT2-Small" \
    --batch_size 16 \
    --val_batch_size 16 \
    --gradient_accumulation_steps 30 \
    --grad_clip 1.0 \
    --warmup_step 2000 \
    --learning_rate 6e-4 \
    --optimizer "adamw" \
    --max_steps 20000 \
    --seed 42 \
    --train_set "pile" \
    --val_set "pile" \
    --eval_interval 1000 \
    --eval_iter 200 \
    --eval_bs 16 \
    --dot_prod_save_interval 1000 \
    --model_dtype "bfloat16" \
    --train_dtype "bfloat16"
```